### PR TITLE
feat(item): generate social images automatically

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -60,6 +60,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Copy .env
+              run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+
             - name: Get Composer cache directory
               id: composer-cache
               run: |
@@ -193,15 +196,23 @@ jobs:
                   MECAB_LIBS: mecab libmecab-dev mecab-ipadic-utf8 php8.2-dev
                   MECAB_PATH: mecab
 
-            - name: Prepare The Environment
-              run: cp .env.example .env
+            - name: Copy .env
+              run: php -r "file_exists('.env') || copy('.env.example', '.env');"
 
-            - name: Create Database
+            - name: Get Composer cache directory
+              id: composer-cache
               run: |
-                  sudo systemctl start mysql
-                  mysql --user="root" --password="root" -e "CREATE DATABASE \`my-database\` character set UTF8mb4 collate utf8mb4_bin;"
+                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-            - name: Install Composer Dependencies
+            - name: Set Composer cache
+              uses: actions/cache@v3
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-
+
+            - name: Install dependencies
               run: composer install --dev --no-ansi --no-interaction --optimize-autoloader
 
             - name: Generate Application Key

--- a/app/Console/Commands/ComputeAllModelsAges.php
+++ b/app/Console/Commands/ComputeAllModelsAges.php
@@ -36,7 +36,7 @@ class ComputeAllModelsAges extends Command
                 $movies->each(function ($movie) {
                     $this->info("Dispatching job for movie {$movie->id}");
 
-                    ComputeModelsAgesJob::dispatch($movie);
+                    ComputeModelsAgesJob::dispatchSync($movie);
                 });
             });
 

--- a/app/Console/Commands/GenerateSocialImages.php
+++ b/app/Console/Commands/GenerateSocialImages.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Jobs\GenerateSocialImage;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+
+class GenerateSocialImages extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:generate-social-images {model}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $class = $this->argument('model');
+
+        /** @var Model */
+        $model = new $class;
+
+        $this->info("Generating social image for {$model}...");
+
+        $model::chunkById(100, function ($items) {
+            foreach ($items as $item) {
+                $this->info("Generating social image for {$item->id}...");
+
+                GenerateSocialImage::dispatchSync($item);
+            }
+        });
+    }
+}

--- a/app/Enums/MediaCollectionType.php
+++ b/app/Enums/MediaCollectionType.php
@@ -6,7 +6,7 @@ namespace App\Enums;
 
 /**
  * Represents the type of the media collection.
- * 
+ *
  * @typescript
  */
 enum MediaCollectionType: string
@@ -18,4 +18,6 @@ enum MediaCollectionType: string
     case Profile = 'profile';
     // Studio
     case Logo = 'logo';
+    // Social Media Preview
+    case SocialMediaPreview = 'social_media_preview';
 }

--- a/app/Events/MovieCreated.php
+++ b/app/Events/MovieCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Movie;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MovieCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Movie $movie
+    ) {
+
+    }
+}

--- a/app/Events/PersonCreated.php
+++ b/app/Events/PersonCreated.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Person;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PersonCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Person $person
+    ) {
+
+    }
+}

--- a/app/Jobs/GenerateSocialImage.php
+++ b/app/Jobs/GenerateSocialImage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Enums\MediaCollectionType;
+use App\Models\Movie;
+use App\Models\Person;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Spatie\Browsershot\Browsershot;
+
+class GenerateSocialImage implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Movie|Person $item
+    ) {
+
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $url = match (true) {
+            $this->item instanceof Movie => route('movies.preview.internal', $this->item),
+            $this->item instanceof Person => route('models.preview.internal', $this->item),
+        };
+
+        $screenshot = Browsershot::url($url)
+            ->setChromePath('/usr/bin/chromium')
+            ->noSandbox()
+            ->showBackground()
+            ->waitUntilNetworkIdle()
+            ->windowSize(1200, 630)
+            ->setScreenshotType('webp', 100)
+            ->screenshot();
+
+        $this->item->addMedia($screenshot)
+            ->toMediaCollection(MediaCollectionType::SocialMediaPreview->value);
+    }
+}

--- a/app/Listeners/AgeUpdateSubscriber.php
+++ b/app/Listeners/AgeUpdateSubscriber.php
@@ -53,12 +53,12 @@ class AgeUpdateSubscriber
     {
         $events->listen(
             'App\Events\MovieUpdated',
-            'App\Listeners\AgeUpdateListener@onMovieUpdate'
+            'App\Listeners\AgeUpdateSubscriber@onMovieUpdate'
         );
 
         $events->listen(
             'App\Events\PersonUpdated',
-            'App\Listeners\AgeUpdateListener@onPersonUpdate'
+            'App\Listeners\AgeUpdateSubscriber@onPersonUpdate'
         );
     }
 }

--- a/app/Listeners/SocialImageUpdateSubscriber.php
+++ b/app/Listeners/SocialImageUpdateSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\MovieUpdated;
+use App\Events\PersonUpdated;
+use App\Jobs\GenerateSocialImage;
+use Illuminate\Events\Dispatcher;
+
+class SocialImageUpdateSubscriber
+{
+    /**
+     * Handle MovieUpdated events.
+     */
+    public function onMovieUpdate(MovieUpdated $event): void
+    {
+        GenerateSocialImage::dispatch($event->movie);
+    }
+
+    /**
+     * Handle PersonUpdated events.
+     */
+    public function onPersonUpdate(PersonUpdated $event): void
+    {
+        GenerateSocialImage::dispatch($event->person);
+    }
+
+    /**
+     * Register the listeners for the subscriber.
+     */
+    public function subscribe(Dispatcher $events): void
+    {
+        $events->listen(
+            'App\Events\MovieCreated',
+            'App\Listeners\SocialImageUpdateSubscriber@onMovieUpdate'
+        );
+
+        $events->listen(
+            'App\Events\MovieUpdated',
+            'App\Listeners\SocialImageUpdateSubscriber@onMovieUpdate'
+        );
+
+        $events->listen(
+            'App\Events\PersonCreated',
+            'App\Listeners\SocialImageUpdateSubscriber@onPersonUpdate'
+        );
+
+        $events->listen(
+            'App\Events\PersonUpdated',
+            'App\Listeners\SocialImageUpdateSubscriber@onPersonUpdate'
+        );
+    }
+}

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Contracts\PopularityContract;
 use App\Enums\MediaCollectionType;
+use App\Events\MovieCreated;
 use App\Events\MovieUpdated;
 use App\Traits\HasPopularity;
 use App\Traits\LockColumns;
@@ -101,6 +102,7 @@ class Movie extends Model implements AuditableContract, HasMedia, PopularityCont
     protected $appends = [
         'poster',
         'fanart',
+        'social_media_preview',
         'in_collection',
         'in_wishlist',
         'in_favorites',
@@ -116,6 +118,7 @@ class Movie extends Model implements AuditableContract, HasMedia, PopularityCont
      * @var array<string, string>
      */
     protected $dispatchesEvents = [
+        'created' => MovieCreated::class,
         'updated' => MovieUpdated::class,
     ];
 
@@ -330,6 +333,18 @@ class Movie extends Model implements AuditableContract, HasMedia, PopularityCont
     }
 
     /**
+     * Returns the movie's social media preview.
+     */
+    protected function socialMediaPreview(): Attribute
+    {
+        return new Attribute(
+            get: function () {
+                return $this->getFirstMedia(MediaCollectionType::SocialMediaPreview->value);
+            }
+        );
+    }
+
+    /**
      * Returns the movie's first front cover.
      *
      * @return Attribute<KanojoMedia|null, never>
@@ -535,6 +550,10 @@ class Movie extends Model implements AuditableContract, HasMedia, PopularityCont
 
         $this->addMediaCollection(MediaCollectionType::FullCover->value)
             ->acceptsMimeTypes(['image/jpeg', 'image/png', 'image/webp']);
+
+        $this->addMediaCollection(MediaCollectionType::SocialMediaPreview->value)
+            ->singleFile()
+            ->acceptsMimeTypes(['image/webp']);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,8 +17,8 @@ class AppServiceProvider extends ServiceProvider
         if ($this->app->isLocal()) {
             $this->app->register(\Barryvdh\Debugbar\ServiceProvider::class);
             $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
+            $this->app->register(\Laravel\Dusk\DuskServiceProvider::class);
         }
-
     }
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,6 +10,7 @@ use App\Listeners\AgeUpdateSubscriber;
 use App\Listeners\ReactionAdded;
 use App\Listeners\ReactionRemoved;
 use App\Listeners\SendNewContentReportNotification;
+use App\Listeners\SocialImageUpdateSubscriber;
 use App\Listeners\UpdateMovieReleaseDate;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenAdded;
 use Cog\Laravel\Love\Reaction\Events\ReactionHasBeenRemoved;
@@ -49,6 +50,7 @@ class EventServiceProvider extends ServiceProvider
      */
     protected $subscribe = [
         AgeUpdateSubscriber::class,
+        SocialImageUpdateSubscriber::class,
     ];
 
     /**

--- a/resources/js/Pages/Item/Show.vue
+++ b/resources/js/Pages/Item/Show.vue
@@ -140,15 +140,9 @@ const shouldShowImage = computed(() => {
         />
 
         <meta
-            v-if="isMovie(props.item)"
+            v-if="isMovie(props.item) || isPerson(props.item)"
             property="og:image"
-            :content="`https://kanojodb.com/movies/${props.item.slug}/preview.webp`"
-        />
-
-        <meta
-            v-else-if="isPerson(props.item)"
-            property="og:image"
-            :content="`https://kanojodb.com/models/${props.item.slug}/preview.webp`"
+            :content="props.item.social_image"
         />
 
         <meta

--- a/resources/js/types/models.d.ts
+++ b/resources/js/types/models.d.ts
@@ -77,6 +77,10 @@ interface Sluggable {
     slug: string;
 }
 
+interface Shareable {
+    social_image: string;
+}
+
 export interface Reactable {
     love_reactant_id: number;
     love_reactant: {
@@ -185,7 +189,7 @@ export interface MovieVersion {
 
 export type MovieVersions = MovieVersion[];
 
-export interface Movie extends Sluggable, Reactable, Linkable {
+export interface Movie extends Sluggable, Reactable, Linkable, Shareable {
     // columns
     id: number;
     title: TranslatableString;
@@ -254,7 +258,7 @@ export interface PersonAlias {
 
 export type PersonAliases = PersonAlias[];
 
-export interface Person extends Sluggable, Linkable {
+export interface Person extends Sluggable, Linkable, Shareable {
     // columns
     id: number;
     name: TranslatableString;


### PR DESCRIPTION
Some websites seem to not quite like the delay caused by us checking R2 for the image, and generating one if it doesn't exist. For example, Discord refuses to show images for any Kanojo links.

A better solution for this is to pre-generate all social images, then directly returning the link to our R2 bucket as the social image for an item.

This adds a SocialMediaPreview media collection type, and defines this collection to be single file on both Movie and Person. A Job then runs on creation and update for both models. Since the collections are single-file, the preview will be replaced automatically.

Fixes #545 