### PR TITLE
feat(user): ability to delete user account

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,10 @@
     "stylelint.reportNeedlessDisables": true,
     "stylelint.validate": ["css", "less", "postcss", "vue", "scss"],
     "vitest.commandLine": "./vendor/bin/sail npm run test --",
-    "vitest.enable": true
+    "vitest.enable": true,
+    "sonarlint.testFilePattern": "{**/test/**,**/*test*,**/*Test*,**/*.spec.*}",
+    "sonarlint.disableTelemetry": true,
+    "sonarlint.connectedMode.project": {
+        "projectKey": "kanojo-db_kanojo"
+    }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class UserController extends Controller
+{
+    /**
+     * Display the specified resource.
+     */
+    public function show(User $user): Response
+    {
+        // Get active_tab query parameter
+        $activeTab = request()->query('active_tab', 'activity');
+
+        return Inertia::render('Profile/Show', [
+            'userProfile' => $user,
+            'editsCount' => $user->audits()->count(),
+            'averageRating' => $user->average_rating,
+            'wishlistCount' => $user->wishlist()->count(),
+            'favoriteCount' => $user->favorites()->count(),
+            'collectionCount' => $user->collection()->count(),
+            'activityThisPastMonth' => function () use ($user) {
+                return $user->audits()
+                    ->where('created_at', '>=', now()->subMonth())
+                    ->get()
+                    ->groupBy('auditable_type')
+                    ->map(function ($audits) {
+                        return $audits->groupBy(function ($audit) {
+                            return $audit->created_at?->format('Y-m-d');
+                        })->map(function ($audits) {
+                            return $audits->count();
+                        })->toArray();
+                    });
+            },
+            'recentActivity' => function () use ($user) {
+                // Ignore for now, it actually exists and is likely a type issue in upstream package
+                // @phpstan-ignore-next-line
+                return $user->audits()
+                    ->where('event', '!=', 'deleted')
+                    ->with('auditable')
+                    ->latest()
+                    ->take(10)
+                    ->get();
+            },
+            'items' => function () use ($activeTab, $user) {
+                $items = null;
+
+                switch ($activeTab) {
+                    case 'wishlist':
+                        $items = $user->wishlist()->with('media')->latest()->paginate(20);
+                        break;
+                    case 'favorites':
+                        $items = $user->favorites()->with('media')->latest()->paginate(20);
+                        break;
+                    case 'collection':
+                    default:
+                        $items = $user->collection()->with('media')->latest()->paginate(20);
+                }
+
+                return $items;
+            },
+        ]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(User $user): RedirectResponse
+    {
+        $user->delete();
+
+        return redirect()->route('welcome');
+    }
+}

--- a/resources/js/Components/Leaderboard.vue
+++ b/resources/js/Components/Leaderboard.vue
@@ -99,7 +99,7 @@ const orderedTopUsers = computed(() => {
                 :key="`top-user-${user.id}`"
                 class="flex w-full flex-row items-center"
             >
-                <Link :href="route('profile.show', user)">
+                <Link :href="route('users.show', user)">
                     <user-avatar
                         :user="user"
                         size="x-large"
@@ -107,7 +107,7 @@ const orderedTopUsers = computed(() => {
                 </Link>
 
                 <div class="ml-4 flex grow flex-col">
-                    <Link :href="route('profile.show', user)">
+                    <Link :href="route('users.show', user)">
                         <user-name
                             class="mb-1 text-2xl font-bold"
                             :user="user"

--- a/resources/js/Components/UserMenu.vue
+++ b/resources/js/Components/UserMenu.vue
@@ -93,7 +93,7 @@ const logout = () => {
             <v-list-item
                 height="72"
                 :to="
-                    route('profile.show', {
+                    route('users.show', {
                         user: userStore.currentUser?.id ?? 0,
                     })
                 "

--- a/resources/js/Pages/Item/Reports.vue
+++ b/resources/js/Pages/Item/Reports.vue
@@ -222,7 +222,7 @@ const loading = ref(false);
                                     <td class="py-2 align-top">
                                         <Link
                                             :href="
-                                                route('profile.show', {
+                                                route('users.show', {
                                                     user: report.reporter.id,
                                                 })
                                             "

--- a/resources/js/Pages/Settings/Account.vue
+++ b/resources/js/Pages/Settings/Account.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { User } from '@/types/models';
 
-import { Head, useForm, usePage } from '@inertiajs/vue3';
+import { Head, router, useForm, usePage } from '@inertiajs/vue3';
+import { ref } from 'vue';
 
 import MdiHelpCircle from '~icons/mdi/help-circle';
 
@@ -33,6 +34,20 @@ const accountSettingsForm = useForm({
 
 function submit() {
     accountSettingsForm.post(route('settings.account.update'));
+}
+
+const isDeleting = ref(false);
+
+function deleteAccount() {
+    if (page.props.user) {
+        isDeleting.value = true;
+
+        router.delete(route('users.destroy', { user: page.props.user.id }), {
+            onFinish: () => {
+                isDeleting.value = false;
+            },
+        });
+    }
 }
 </script>
 
@@ -74,68 +89,113 @@ function submit() {
         </template>
 
         <template #right>
-            <!--<q-banner
-                        v-if="$page.props.jetstream.flash.banner"
-                        class="text-stone-50 q-mb-sm"
-                        :class="{
-                            'bg-positive':
-                                $page.props.jetstream.flash.bannerStyle ===
-                                'success',
-                            'bg-negative':
-                                $page.props.jetstream.flash.bannerStyle ===
-                                'error',
-                        }"
-                    >
-                        {{ $page.props.jetstream.flash.banner }}
-                    </q-banner>-->
             <v-form @submit.prevent="submit">
-                <div class="flex flex-row gap-2">
-                    <h3 class="text-xl font-bold">
-                        {{ $t('settings.account.content_visibility') }}
-                    </h3>
+                <v-row>
+                    <v-col>
+                        <div class="flex flex-row gap-2">
+                            <h3 class="text-xl font-bold">
+                                {{ $t('settings.account.content_visibility') }}
+                            </h3>
 
-                    <v-tooltip
-                        :text="
-                            $t('settings.account.content_visibility_tooltip')
-                        "
-                    >
-                        <template #activator="{ props: tooltipProps }">
-                            <v-icon
-                                v-bind="tooltipProps"
-                                :icon="MdiHelpCircle"
-                            />
-                        </template>
-                    </v-tooltip>
-                </div>
+                            <v-tooltip
+                                :text="
+                                    $t(
+                                        'settings.account.content_visibility_tooltip',
+                                    )
+                                "
+                            >
+                                <template #activator="{ props: tooltipProps }">
+                                    <v-icon
+                                        v-bind="tooltipProps"
+                                        :icon="MdiHelpCircle"
+                                    />
+                                </template>
+                            </v-tooltip>
+                        </div>
+                    </v-col>
+                </v-row>
 
-                <v-switch
-                    v-model="accountSettingsForm.show_jav"
-                    disabled
-                    :label="$t('settings.account.show_adult_content')"
-                    hide-details
-                />
+                <v-row>
+                    <v-col>
+                        <v-switch
+                            v-model="accountSettingsForm.show_jav"
+                            disabled
+                            :label="$t('settings.account.show_adult_content')"
+                            hide-details
+                        />
+                    </v-col>
+                </v-row>
 
-                <v-switch
-                    v-model="accountSettingsForm.show_gravure"
-                    disabled
-                    :label="$t('settings.account.show_gravure_content')"
-                    hide-details
-                />
+                <v-row>
+                    <v-col>
+                        <v-switch
+                            v-model="accountSettingsForm.show_gravure"
+                            disabled
+                            :label="$t('settings.account.show_gravure_content')"
+                            hide-details
+                        />
+                    </v-col>
+                </v-row>
 
-                <v-switch
-                    v-model="accountSettingsForm.show_minors"
-                    disabled
-                    :label="$t('settings.account.show_gravure_minors_content')"
-                    hide-details
-                />
+                <v-row>
+                    <v-col>
+                        <v-switch
+                            v-model="accountSettingsForm.show_minors"
+                            disabled
+                            :label="
+                                $t(
+                                    'settings.account.show_gravure_minors_content',
+                                )
+                            "
+                            hide-details
+                        />
+                    </v-col>
+                </v-row>
 
-                <v-btn
-                    type="submit"
-                    color="primary"
-                    disabled
-                    :text="$t('general.saveChanges')"
-                    class="mt-2"
-                />
+                <v-row>
+                    <v-col>
+                        <v-btn
+                            type="submit"
+                            color="primary"
+                            disabled
+                            :text="$t('general.saveChanges')"
+                            class="mt-2"
+                        />
+                    </v-col>
+                </v-row>
+
+                <v-row>
+                    <v-col>
+                        <v-card
+                            border
+                            class="border-red-500"
+                            variant="flat"
+                        >
+                            <v-card-title class="font-black">
+                                {{ $t('settings.account.dangerZone') }}
+                            </v-card-title>
+
+                            <v-card-text
+                                class="flex flex-col items-start gap-4"
+                            >
+                                <p
+                                    class="prose"
+                                    v-text="
+                                        $t('settings.account.deleteAccountInfo')
+                                    "
+                                />
+
+                                <v-btn
+                                    color="red"
+                                    :loading="isDeleting"
+                                    @click="deleteAccount"
+                                >
+                                    {{ $t('settings.account.deleteAccount') }}
+                                </v-btn>
+                            </v-card-text>
+                        </v-card>
+                    </v-col>
+                </v-row>
             </v-form>
         </template>
     </side-menu-page>

--- a/resources/js/locales/en-US.json
+++ b/resources/js/locales/en-US.json
@@ -1,656 +1,659 @@
 {
-  "$vuetify": {
-    "badge": "Badge",
-    "calendar": {
-      "moreEvents": "{0} more"
+    "$vuetify": {
+        "badge": "Badge",
+        "calendar": {
+            "moreEvents": "{0} more"
+        },
+        "carousel": {
+            "ariaLabel": {
+                "delimiter": "Carousel slide {0} of {1}"
+            },
+            "next": "Next visual",
+            "prev": "Previous visual"
+        },
+        "close": "Close",
+        "dataFooter": {
+            "firstPage": "First page",
+            "itemsPerPageAll": "All",
+            "itemsPerPageText": "Items per page:",
+            "lastPage": "Last page",
+            "nextPage": "Next page",
+            "pageText": "{0}-{1} of {2}",
+            "prevPage": "Previous page"
+        },
+        "dataIterator": {
+            "loadingText": "Loading items...",
+            "noResultsText": "No matching records found"
+        },
+        "dataTable": {
+            "ariaLabel": {
+                "activateAscending": "Activate to sort ascending.",
+                "activateDescending": "Activate to sort descending.",
+                "activateNone": "Activate to remove sorting.",
+                "sortAscending": "Sorted ascending.",
+                "sortDescending": "Sorted descending.",
+                "sortNone": "Not sorted."
+            },
+            "itemsPerPageText": "Rows per page:",
+            "sortBy": "Sort by"
+        },
+        "datePicker": {
+            "cancel": "Cancel",
+            "header": "Enter date",
+            "input": {
+                "placeholder": "Enter date"
+            },
+            "ok": "OK",
+            "range": {
+                "header": "Enter dates",
+                "title": "Select dates"
+            },
+            "title": "Select date"
+        },
+        "dateRangeInput": {
+            "divider": "to"
+        },
+        "fileInput": {
+            "counter": "{0} files",
+            "counterSize": "{0} files ({1} in total)"
+        },
+        "infiniteScroll": {
+            "empty": "No more",
+            "loadMore": "Load more"
+        },
+        "input": {
+            "appendAction": "{0} appended action",
+            "clear": "Clear {0}",
+            "otp": "Please enter OTP character {0}",
+            "prependAction": "{0} prepended action"
+        },
+        "loading": "Loading...",
+        "noDataText": "No data available",
+        "open": "Open",
+        "pagination": {
+            "ariaLabel": {
+                "currentPage": "Page {0}, Current page",
+                "first": "First page",
+                "last": "Last page",
+                "next": "Next page",
+                "page": "Go to page {0}",
+                "previous": "Previous page",
+                "root": "Pagination Navigation"
+            }
+        },
+        "rating": {
+            "ariaLabel": {
+                "item": "Rating {0} of {1}"
+            }
+        },
+        "stepper": {
+            "next": "Next",
+            "prev": "Previous"
+        },
+        "timePicker": {
+            "am": "AM",
+            "pm": "PM"
+        }
     },
-    "carousel": {
-      "ariaLabel": {
-        "delimiter": "Carousel slide {0} of {1}"
-      },
-      "next": "Next visual",
-      "prev": "Previous visual"
+    "about": {
+        "averageMoviesPerModel": "Average number of movies per model",
+        "community": "community-run",
+        "distributionModelsPerYearOfBirth": "Distribution of models per year of birth*",
+        "distributionModelsPerYearOfBirthNote": "* Data only includes models with a known birth year.",
+        "distributionMoviesPerAgeOfPerformer": "Distribution of movies per age of performers*",
+        "distributionMoviesPerAgeOfPerformerNote": "* Data only includes movies with known age of performers.",
+        "distributionMoviesPerYear": "Distribution of movies per year of production*",
+        "distributionMoviesPerYearInfo": "* Data only includes movies with a known production year.",
+        "distributionOfModelsPerBustSize": "Distribution of models per bust size*",
+        "distributionOfModelsPerBustSizeNote": "* Data only includes models with a known bust size.",
+        "distributionOfModelsPerCupSize": "Distribution of models per bra cup size*",
+        "distributionOfModelsPerCupSizeNote": "* Data only includes models with a known bra cup size.",
+        "distributionOfModelsPerHeight": "Distribution of models per height*",
+        "distributionOfModelsPerHeightNote": "* Data only includes models with a known height.",
+        "distributionOfModelsPerHipSize": "Distribution of models per hip size*",
+        "distributionOfModelsPerHipSizeNote": "* Data only includes models with a known hip size.",
+        "distributionOfModelsPerWaistSize": "Distribution of models per waist size*",
+        "distributionOfModelsPerWaistSizeNote": "* Data only includes models with a known waist size.",
+        "moviesWithoutPoster": "Movies without poster",
+        "point1": "An extensive database of information on movies, studios and models, complete with images. It includes everything you need to find your next favorite title, from content tags to detailed model information.",
+        "point2": "No more need to scrape online stores or evade IP bans to get the information you need. We provide a comprehensive and easy-to-use API for developers, to integrate our data with your tool or service.",
+        "point3": "Built by people like you. We made Kanojo to solve some of the issues we have had with other sites and tools over the past 10 years.",
+        "statsHeader": "Some Stats",
+        "statsIntro": "Cool people like to see numbers and charts. Here are a few we think you'll find interesting.",
+        "subtitle": "Every piece of data is user-submitted and user-curated,{0} with a focus on providing high quality information.",
+        "title": "Kanojo is a {0} Japanese adult video and gravure movie database"
     },
-    "close": "Close",
-    "dataFooter": {
-      "firstPage": "First page",
-      "itemsPerPageAll": "All",
-      "itemsPerPageText": "Items per page:",
-      "lastPage": "Last page",
-      "nextPage": "Next page",
-      "pageText": "{0}-{1} of {2}",
-      "prevPage": "Previous page"
+    "admin": {
+        "horizon": "Horizon",
+        "telescope": "Telescope"
     },
-    "dataIterator": {
-      "loadingText": "Loading items...",
-      "noResultsText": "No matching records found"
+    "dialog": {
+        "addCast": {
+            "name": "Name"
+        }
     },
-    "dataTable": {
-      "ariaLabel": {
-        "activateAscending": "Activate to sort ascending.",
-        "activateDescending": "Activate to sort descending.",
-        "activateNone": "Activate to remove sorting.",
-        "sortAscending": "Sorted ascending.",
-        "sortDescending": "Sorted descending.",
-        "sortNone": "Not sorted."
-      },
-      "itemsPerPageText": "Rows per page:",
-      "sortBy": "Sort by"
+    "dialogs": {
+        "addCast": {
+            "title": "Add cast member to {itemTitle}"
+        },
+        "confirmDelete": {
+            "body": "Are you sure you want to delete this item?",
+            "cancel": "Cancel",
+            "delete": "Delete",
+            "title": "Delete {itemName}"
+        },
+        "create_alias": {
+            "name": "Name",
+            "title": "Create an alias"
+        },
+        "create_token": {
+            "description": "Give a unique name to your API token to help you identify it later.",
+            "title": "Create an API Token"
+        },
+        "editMovieVersion": {
+            "format": {
+                "bluray": "Blu-ray",
+                "digital": "Digital",
+                "dvd": "DVD",
+                "hddvd": "HD DVD",
+                "laserdisc": "Laserdisc",
+                "uhdBluray": "UHD Blu-ray",
+                "umd": "UMD",
+                "vhs": "VHS"
+            },
+            "title": "Edit version for {itemTitle}"
+        },
+        "media_upload": {
+            "instructions": "Select a profile picture by clicking on the button below and\n            selecting an image on your computer.",
+            "requirements_1": "A maximum resolution of 2000x3000",
+            "requirements_2": "A minimum resolution of 300x450",
+            "requirements_3": "Aspect ratio of 1{1}.5 (2{3})",
+            "requirements_heading": "Profile images must meet the following criteria:",
+            "submit": "Upload",
+            "title": "Upload Media"
+        },
+        "reportContent": {
+            "additional_information": "Additional Information",
+            "bad_image": "Bad Image",
+            "duplicate": "Duplicate",
+            "in_progress": "In Progress",
+            "incorrect": "Incorrect Content",
+            "information": "Information:",
+            "invalid": "Invalid",
+            "noReports": "No reports found.",
+            "open": "Open",
+            "other": "Other",
+            "public_report": "Make this report public",
+            "rejected": "Rejected",
+            "report": "Report",
+            "resolved": "Resolved",
+            "spam": "Spam",
+            "subject": "Reported a problem for {title}",
+            "title": "Report a content issue",
+            "type": "Type:",
+            "type_of_problem": "Type of Problem",
+            "types": {
+                "bad_image": "Bad Image",
+                "duplicate": "Duplicate",
+                "incorrect": "Incorrect Content",
+                "other": "Other",
+                "spam": "Spam"
+            },
+            "visibilities": {
+                "private": "Private",
+                "public": "Public"
+            },
+            "visibility": "Visibility:"
+        },
+        "shareLink": {
+            "title": "Share {pageName}",
+            "url": "URL"
+        },
+        "versionCreate": {
+            "title": "Add a version to {itemTitle}"
+        }
     },
-    "datePicker": {
-      "cancel": "Cancel",
-      "header": "Enter date",
-      "input": {
-        "placeholder": "Enter date"
-      },
-      "ok": "OK",
-      "range": {
-        "header": "Enter dates",
-        "title": "Select dates"
-      },
-      "title": "Select date"
+    "edit": {
+        "alias": {
+            "name": "Name"
+        },
+        "aliases": {
+            "add": "Add an alias"
+        },
+        "cast": {
+            "add": "Add a cast member",
+            "lock": "Lock",
+            "person": "Person"
+        },
+        "sections": {
+            "alternativeNames": "Alternative Names",
+            "cast": "Cast",
+            "externalIds": "External IDs",
+            "primaryFacts": "Primary Facts",
+            "scenes": "Scenes",
+            "versions": "Versions"
+        },
+        "version": {
+            "add": "Add a version"
+        }
     },
-    "dateRangeInput": {
-      "divider": "to"
+    "general": {
+        "addModel": "Add Model",
+        "addMovie": "Add Movie",
+        "addSeries": "Add Movie Series",
+        "addStudio": "Add Studio",
+        "backToOverview": "Back to overview",
+        "clear": "Clear",
+        "comingSoon": "Soon",
+        "confirmPassword": "Confirm",
+        "copy": "Copy",
+        "darkMode": "Dark Mode",
+        "delete": "Delete",
+        "download": "Download",
+        "edit": "Edit",
+        "email": "Email",
+        "forgotPassword": "Please enter your email address and we will send you a link to reset your password.",
+        "links": "Links",
+        "login": "Login",
+        "logout": "Logout",
+        "maintenance": {
+            "description1": "Kanojo is currently undergoing scheduled maintenance to                         enhance your experience.",
+            "description3": "We apologize for any inconvenience this may cause.",
+            "title": "Maintenance in Progress - We'll be back shortly!"
+        },
+        "mediaServerPlugins": {
+            "description": "Our official plugins are available for all major media players",
+            "downloadNow": "Download now",
+            "match": {
+                "description1": "Our plugins are designed to be as easy to use as possible. Simply install the plugin, enter your API token and you're good to go.",
+                "description2": "The plugin will automatically match your media with the correct metadata and artwork.",
+                "description3": "You can also leverage our powerful search engine to fix any incorrect matches.",
+                "title": "As easy as 1, 2, 3"
+            },
+            "metadata": {
+                "description1": "Our plugins are tailored to each media player to ensure the best possible experience.",
+                "description2": "We provide detailed metadata for all your content, including cast, director, genres, release dates, artwork and more.",
+                "description3": "We make sure to provide all the information you need to make your media player look great and find the content you want to watch.",
+                "title": "Detailed and accurate"
+            },
+            "title": "Enhance your media player with top quality metadata"
+        },
+        "movieCount": "No movies | 1 movie | {count} movies",
+        "newPassword": "New Password",
+        "notSet": "Not set",
+        "not_rated": "NR",
+        "notification": {
+            "contentReportCreated": "A new content report has been submitted.",
+            "description": "Message",
+            "goToItem": "Go to item",
+            "markAsRead": "Mark as read",
+            "noNotifications": "No notifications.",
+            "recievedAt": "Received at",
+            "unknown": "Unknown notification type."
+        },
+        "notifications": "Notifications",
+        "pages": {
+            "about": "About Kanojo",
+            "add_movie": "Add a Movie",
+            "ageGate": {
+                "confirm": "Enter",
+                "description1": "Some of the items on this website feature nudity and/or sexually explicit content.",
+                "description2": "By entering this website you agree that you are at least 18 years old or the legal age to view adult content in your country.",
+                "description3": "This website does not provide any downloads or streams, and acts as a database and search engine for Japanese adult content and gravure idols.",
+                "title": "This website contains adult content!"
+            },
+            "age_gate": "Confirm your age",
+            "api": "API",
+            "bible": "Contribution Bible",
+            "community": "Community",
+            "contactUs": "Contact Us",
+            "contentIssues": "Content Issues",
+            "contentReports": "Content Reports",
+            "contribute": "Contribute",
+            "create": {
+                "movie": "Create a Movie",
+                "person": "Create a Model",
+                "series": "Create a Series",
+                "studio": "Create a Studio"
+            },
+            "delete": "Delete",
+            "discord": "Discord",
+            "fill_missing": "Fill Missing Data",
+            "general": "General",
+            "github": "GitHub",
+            "helpTranslate": "Help Translate Kanojo",
+            "mastodon": "Mastodon",
+            "merge": "Merge",
+            "plugins": "Plugins",
+            "privacyPolicy": "Privacy Policy",
+            "requestFeatures": "Request Features",
+            "search": "Search",
+            "settings": "Settings",
+            "status": "Status",
+            "twitter": "Twitter"
+        },
+        "password": "Password",
+        "present": "Present",
+        "register": "Register",
+        "resendVerificationEmail": "Resend Verification Email",
+        "resentVerificationLink": "Resend verification link",
+        "resetPassword": "Reset Password",
+        "saveChanges": "Save",
+        "search": "Search",
+        "search_placeholder": "Search a title, product code or model…",
+        "send": "Send",
+        "sendPasswordResetLink": "Send a password reset link",
+        "sortBy": "Sort by",
+        "submit": "Submit",
+        "unknown": "Unknown",
+        "useRecoveryCode": "Use a recovery code",
+        "useTwoFactorCode": "Use a two-factor code",
+        "username": "Username",
+        "verificationLinkSent": "A new verification link has been sent to the email address you provided during registration.",
+        "verifyEmail": "To complete the registration process, we need to verify your email address. We have sent a verification link to the email address you provided during registration.",
+        "view_profile": "View Profile",
+        "x_percent": "{number}%",
+        "years_old": "{age} years old"
     },
-    "fileInput": {
-      "counter": "{0} files",
-      "counterSize": "{0} files ({1} in total)"
+    "global": {
+        "language": {
+            "defaultLanguage": "Default Language",
+            "fallbackLanguage": "Fallback Language"
+        }
     },
-    "infiniteScroll": {
-      "empty": "No more",
-      "loadMore": "Load more"
+    "history": {
+        "actionOnDate": "{action} on {date}",
+        "events": {
+            "updated": "Updated"
+        },
+        "noChanges": "No changes found.",
+        "numberOfChanges": "No changes | 1 change | {number} changes"
     },
-    "input": {
-      "appendAction": "{0} appended action",
-      "clear": "Clear {0}",
-      "otp": "Please enter OTP character {0}",
-      "prependAction": "{0} prepended action"
+    "item": {
+        "3d": "3D",
+        "links": {
+            "none": "No known links."
+        },
+        "media": {
+            "addedOn": "Added on:",
+            "no_media": "No media found."
+        },
+        "pagination": {
+            "noItems": "There is nothing here."
+        },
+        "vr": "VR"
     },
-    "loading": "Loading...",
-    "noDataText": "No data available",
-    "open": "Open",
-    "pagination": {
-      "ariaLabel": {
-        "currentPage": "Page {0}, Current page",
-        "first": "First page",
-        "last": "Last page",
-        "next": "Next page",
-        "page": "Go to page {0}",
-        "previous": "Previous page",
-        "root": "Pagination Navigation"
-      }
-    },
-    "rating": {
-      "ariaLabel": {
-        "item": "Rating {0} of {1}"
-      }
-    },
-    "stepper": {
-      "next": "Next",
-      "prev": "Previous"
-    },
-    "timePicker": {
-      "am": "AM",
-      "pm": "PM"
-    }
-  },
-  "about": {
-    "averageMoviesPerModel": "Average number of movies per model",
-    "community": "community-run",
-    "distributionModelsPerYearOfBirth": "Distribution of models per year of birth*",
-    "distributionModelsPerYearOfBirthNote": "* Data only includes models with a known birth year.",
-    "distributionMoviesPerAgeOfPerformer": "Distribution of movies per age of performers*",
-    "distributionMoviesPerAgeOfPerformerNote": "* Data only includes movies with known age of performers.",
-    "distributionMoviesPerYear": "Distribution of movies per year of production*",
-    "distributionMoviesPerYearInfo": "* Data only includes movies with a known production year.",
-    "distributionOfModelsPerBustSize": "Distribution of models per bust size*",
-    "distributionOfModelsPerBustSizeNote": "* Data only includes models with a known bust size.",
-    "distributionOfModelsPerCupSize": "Distribution of models per bra cup size*",
-    "distributionOfModelsPerCupSizeNote": "* Data only includes models with a known bra cup size.",
-    "distributionOfModelsPerHeight": "Distribution of models per height*",
-    "distributionOfModelsPerHeightNote": "* Data only includes models with a known height.",
-    "distributionOfModelsPerHipSize": "Distribution of models per hip size*",
-    "distributionOfModelsPerHipSizeNote": "* Data only includes models with a known hip size.",
-    "distributionOfModelsPerWaistSize": "Distribution of models per waist size*",
-    "distributionOfModelsPerWaistSizeNote": "* Data only includes models with a known waist size.",
-    "moviesWithoutPoster": "Movies without poster",
-    "point1": "An extensive database of information on movies, studios and models, complete with images. It includes everything you need to find your next favorite title, from content tags to detailed model information.",
-    "point2": "No more need to scrape online stores or evade IP bans to get the information you need. We provide a comprehensive and easy-to-use API for developers, to integrate our data with your tool or service.",
-    "point3": "Built by people like you. We made Kanojo to solve some of the issues we have had with other sites and tools over the past 10 years.",
-    "statsHeader": "Some Stats",
-    "statsIntro": "Cool people like to see numbers and charts. Here are a few we think you'll find interesting.",
-    "subtitle": "Every piece of data is user-submitted and user-curated,{0} with a focus on providing high quality information.",
-    "title": "Kanojo is a {0} Japanese adult video and gravure movie database"
-  },
-  "admin": {
-    "horizon": "Horizon",
-    "telescope": "Telescope"
-  },
-  "dialog": {
-    "addCast": {
-      "name": "Name"
-    }
-  },
-  "dialogs": {
-    "addCast": {
-      "title": "Add cast member to {itemTitle}"
-    },
-    "confirmDelete": {
-      "body": "Are you sure you want to delete this item?",
-      "cancel": "Cancel",
-      "delete": "Delete",
-      "title": "Delete {itemName}"
-    },
-    "create_alias": {
-      "name": "Name",
-      "title": "Create an alias"
-    },
-    "create_token": {
-      "description": "Give a unique name to your API token to help you identify it later.",
-      "title": "Create an API Token"
-    },
-    "editMovieVersion": {
-      "format": {
-        "bluray": "Blu-ray",
-        "digital": "Digital",
-        "dvd": "DVD",
-        "hddvd": "HD DVD",
-        "laserdisc": "Laserdisc",
-        "uhdBluray": "UHD Blu-ray",
-        "umd": "UMD",
-        "vhs": "VHS"
-      },
-      "title": "Edit version for {itemTitle}"
-    },
-    "media_upload": {
-      "instructions": "Select a profile picture by clicking on the button below and\n            selecting an image on your computer.",
-      "requirements_1": "A maximum resolution of 2000x3000",
-      "requirements_2": "A minimum resolution of 300x450",
-      "requirements_3": "Aspect ratio of 1{1}.5 (2{3})",
-      "requirements_heading": "Profile images must meet the following criteria:",
-      "submit": "Upload",
-      "title": "Upload Media"
-    },
-    "reportContent": {
-      "additional_information": "Additional Information",
-      "bad_image": "Bad Image",
-      "duplicate": "Duplicate",
-      "in_progress": "In Progress",
-      "incorrect": "Incorrect Content",
-      "information": "Information:",
-      "invalid": "Invalid",
-      "noReports": "No reports found.",
-      "open": "Open",
-      "other": "Other",
-      "public_report": "Make this report public",
-      "rejected": "Rejected",
-      "report": "Report",
-      "resolved": "Resolved",
-      "spam": "Spam",
-      "subject": "Reported a problem for {title}",
-      "title": "Report a content issue",
-      "type": "Type:",
-      "type_of_problem": "Type of Problem",
-      "types": {
-        "bad_image": "Bad Image",
-        "duplicate": "Duplicate",
-        "incorrect": "Incorrect Content",
-        "other": "Other",
-        "spam": "Spam"
-      },
-      "visibilities": {
-        "private": "Private",
-        "public": "Public"
-      },
-      "visibility": "Visibility:"
-    },
-    "shareLink": {
-      "title": "Share {pageName}",
-      "url": "URL"
-    },
-    "versionCreate": {
-      "title": "Add a version to {itemTitle}"
-    }
-  },
-  "edit": {
-    "alias": {
-      "name": "Name"
-    },
-    "aliases": {
-      "add": "Add an alias"
-    },
-    "cast": {
-      "add": "Add a cast member",
-      "lock": "Lock",
-      "person": "Person"
-    },
-    "sections": {
-      "alternativeNames": "Alternative Names",
-      "cast": "Cast",
-      "externalIds": "External IDs",
-      "primaryFacts": "Primary Facts",
-      "scenes": "Scenes",
-      "versions": "Versions"
-    },
-    "version": {
-      "add": "Add a version"
-    }
-  },
-  "general": {
-    "addModel": "Add Model",
-    "addMovie": "Add Movie",
-    "addSeries": "Add Movie Series",
-    "addStudio": "Add Studio",
-    "backToOverview": "Back to overview",
-    "clear": "Clear",
-    "comingSoon": "Soon",
-    "confirmPassword": "Confirm",
-    "copy": "Copy",
-    "darkMode": "Dark Mode",
-    "delete": "Delete",
-    "download": "Download",
-    "edit": "Edit",
-    "email": "Email",
-    "forgotPassword": "Please enter your email address and we will send you a link to reset your password.",
-    "links": "Links",
-    "login": "Login",
-    "logout": "Logout",
-    "maintenance": {
-      "description1": "Kanojo is currently undergoing scheduled maintenance to                         enhance your experience.",
-      "description3": "We apologize for any inconvenience this may cause.",
-      "title": "Maintenance in Progress - We'll be back shortly!"
-    },
-    "mediaServerPlugins": {
-      "description": "Our official plugins are available for all major media players",
-      "downloadNow": "Download now",
-      "match": {
-        "description1": "Our plugins are designed to be as easy to use as possible. Simply install the plugin, enter your API token and you're good to go.",
-        "description2": "The plugin will automatically match your media with the correct metadata and artwork.",
-        "description3": "You can also leverage our powerful search engine to fix any incorrect matches.",
-        "title": "As easy as 1, 2, 3"
-      },
-      "metadata": {
-        "description1": "Our plugins are tailored to each media player to ensure the best possible experience.",
-        "description2": "We provide detailed metadata for all your content, including cast, director, genres, release dates, artwork and more.",
-        "description3": "We make sure to provide all the information you need to make your media player look great and find the content you want to watch.",
-        "title": "Detailed and accurate"
-      },
-      "title": "Enhance your media player with top quality metadata"
-    },
-    "movieCount": "No movies | 1 movie | {count} movies",
-    "newPassword": "New Password",
-    "notSet": "Not set",
-    "not_rated": "NR",
-    "notification": {
-      "contentReportCreated": "A new content report has been submitted.",
-      "description": "Message",
-      "goToItem": "Go to item",
-      "markAsRead": "Mark as read",
-      "noNotifications": "No notifications.",
-      "recievedAt": "Received at",
-      "unknown": "Unknown notification type."
-    },
-    "notifications": "Notifications",
-    "pages": {
-      "about": "About Kanojo",
-      "add_movie": "Add a Movie",
-      "ageGate": {
-        "confirm": "Enter",
-        "description1": "Some of the items on this website feature nudity and/or sexually explicit content.",
-        "description2": "By entering this website you agree that you are at least 18 years old or the legal age to view adult content in your country.",
-        "description3": "This website does not provide any downloads or streams, and acts as a database and search engine for Japanese adult content and gravure idols.",
-        "title": "This website contains adult content!"
-      },
-      "age_gate": "Confirm your age",
-      "api": "API",
-      "bible": "Contribution Bible",
-      "community": "Community",
-      "contactUs": "Contact Us",
-      "contentIssues": "Content Issues",
-      "contentReports": "Content Reports",
-      "contribute": "Contribute",
-      "create": {
-        "movie": "Create a Movie",
-        "person": "Create a Model",
-        "series": "Create a Series",
-        "studio": "Create a Studio"
-      },
-      "delete": "Delete",
-      "discord": "Discord",
-      "fill_missing": "Fill Missing Data",
-      "general": "General",
-      "github": "GitHub",
-      "helpTranslate": "Help Translate Kanojo",
-      "mastodon": "Mastodon",
-      "merge": "Merge",
-      "plugins": "Plugins",
-      "privacyPolicy": "Privacy Policy",
-      "requestFeatures": "Request Features",
-      "search": "Search",
-      "settings": "Settings",
-      "status": "Status",
-      "twitter": "Twitter"
-    },
-    "password": "Password",
-    "present": "Present",
-    "register": "Register",
-    "resendVerificationEmail": "Resend Verification Email",
-    "resentVerificationLink": "Resend verification link",
-    "resetPassword": "Reset Password",
-    "saveChanges": "Save",
-    "search": "Search",
-    "search_placeholder": "Search a title, product code or model…",
-    "send": "Send",
-    "sendPasswordResetLink": "Send a password reset link",
-    "sortBy": "Sort by",
-    "submit": "Submit",
-    "unknown": "Unknown",
-    "useRecoveryCode": "Use a recovery code",
-    "useTwoFactorCode": "Use a two-factor code",
-    "username": "Username",
-    "verificationLinkSent": "A new verification link has been sent to the email address you provided during registration.",
-    "verifyEmail": "To complete the registration process, we need to verify your email address. We have sent a verification link to the email address you provided during registration.",
-    "view_profile": "View Profile",
-    "x_percent": "{number}%",
-    "years_old": "{age} years old"
-  },
-  "global": {
-    "language": {
-      "defaultLanguage": "Default Language",
-      "fallbackLanguage": "Fallback Language"
-    }
-  },
-  "history": {
-    "actionOnDate": "{action} on {date}",
-    "events": {
-      "updated": "Updated"
-    },
-    "noChanges": "No changes found.",
-    "numberOfChanges": "No changes | 1 change | {number} changes"
-  },
-  "item": {
-    "3d": "3D",
-    "links": {
-      "none": "No known links."
+    "login": {
+        "forgotPassword": "Forgot your password?",
+        "marketingHeader": "Already a member? Sign in to explore our comprehensive database of titles and models.",
+        "needAccount": "Need an account?",
+        "submit": "Log in",
+        "welcomeBack": "Welcome back to Kanojo - largest database of Japanese adult video and gravure movies!"
     },
     "media": {
-      "addedOn": "Added on:",
-      "no_media": "No media found."
+        "title": "Media",
+        "types": {
+            "front_cover": "Front Cover",
+            "full_cover": "Full Cover",
+            "logo": "Logo",
+            "profile": "Profile"
+        }
     },
-    "pagination": {
-      "noItems": "There is nothing here."
+    "model": {
+        "active": "Active:",
+        "alsoKnownAs": "Also Known As",
+        "birth_date": "Birth Date:",
+        "blood_type": "Blood Type:",
+        "breasts_implant": "(Implants)",
+        "breasts_natural": "(Natural)",
+        "bust": "Bust:",
+        "careerSpan": "{start} - {end}",
+        "country": "Country:",
+        "cup_size": "Cup Size:",
+        "height": "Height:",
+        "hips": "Hips:",
+        "noKnownAliases": "No known aliases.",
+        "starredMovied": "Movies",
+        "unit_cm": "{number}cm",
+        "waist": "Waist:"
     },
-    "vr": "VR"
-  },
-  "login": {
-    "forgotPassword": "Forgot your password?",
-    "marketingHeader": "Already a member? Sign in to explore our comprehensive database of titles and models.",
-    "needAccount": "Need an account?",
-    "submit": "Log in",
-    "welcomeBack": "Welcome back to Kanojo - largest database of Japanese adult video and gravure movies!"
-  },
-  "media": {
-    "title": "Media",
-    "types": {
-      "front_cover": "Front Cover",
-      "full_cover": "Full Cover",
-      "logo": "Logo",
-      "profile": "Profile"
-    }
-  },
-  "model": {
-    "active": "Active:",
-    "alsoKnownAs": "Also Known As",
-    "birth_date": "Birth Date:",
-    "blood_type": "Blood Type:",
-    "breasts_implant": "(Implants)",
-    "breasts_natural": "(Natural)",
-    "bust": "Bust:",
-    "careerSpan": "{start} - {end}",
-    "country": "Country:",
-    "cup_size": "Cup Size:",
-    "height": "Height:",
-    "hips": "Hips:",
-    "noKnownAliases": "No known aliases.",
-    "starredMovied": "Movies",
-    "unit_cm": "{number}cm",
-    "waist": "Waist:"
-  },
-  "models": {
-    "bustSize": "Bust Size",
-    "height": "Height",
-    "hipSize": "Hip Size",
-    "sort": {
-      "birthdate": "Birthdate",
-      "birthdateDesc": "Birthdate (desc)",
-      "bust": "Bust",
-      "bustDesc": "Bust (desc)",
-      "createdAt": "Created at",
-      "createdAtDesc": "Created at (desc)",
-      "height": "Height",
-      "heightDesc": "Height (desc)",
-      "hip": "Hip",
-      "hipDesc": "Hip (desc)",
-      "movies": "Number of movies",
-      "moviesDesc": "Number of movies (desc)",
-      "popularity": "Popularity",
-      "popularityDesc": "Popularity (desc)",
-      "updatedAt": "Updated at",
-      "updatedAtDesc": "Updated at (desc)",
-      "waist": "Waist",
-      "waistDesc": "Waist (desc)"
+    "models": {
+        "bustSize": "Bust Size",
+        "height": "Height",
+        "hipSize": "Hip Size",
+        "sort": {
+            "birthdate": "Birthdate",
+            "birthdateDesc": "Birthdate (desc)",
+            "bust": "Bust",
+            "bustDesc": "Bust (desc)",
+            "createdAt": "Created at",
+            "createdAtDesc": "Created at (desc)",
+            "height": "Height",
+            "heightDesc": "Height (desc)",
+            "hip": "Hip",
+            "hipDesc": "Hip (desc)",
+            "movies": "Number of movies",
+            "moviesDesc": "Number of movies (desc)",
+            "popularity": "Popularity",
+            "popularityDesc": "Popularity (desc)",
+            "updatedAt": "Updated at",
+            "updatedAtDesc": "Updated at (desc)",
+            "waist": "Waist",
+            "waistDesc": "Waist (desc)"
+        },
+        "sortBy": "Sort by",
+        "waistSize": "Waist Size",
+        "yearOfBirth": "Year of birth"
     },
-    "sortBy": "Sort by",
-    "waistSize": "Waist Size",
-    "yearOfBirth": "Year of birth"
-  },
-  "movie": {
-    "reports": {
-      "opened_at": "Opened {date}",
-      "report_type": "Report Type:",
-      "x_reports": "No Reports | {count} Report | {count} Reports"
-    },
-    "show": {
-      "add_to_collection": "Add to Collection",
-      "add_to_favorites": "Add to Favorites",
-      "add_to_wishlist": "Add to Wishlist",
-      "age": "({age} years old)",
-      "barcode": "Barcode",
-      "born": "Born:",
-      "dislike": "Dislike",
-      "files": "Files",
-      "format": "Format",
-      "from": "From {country}",
-      "like": "Like",
-      "measurements": "{height}cm, {bust}-{waist}-{hip}cm",
-      "models": "Models",
-      "noModels": "No model information.",
-      "no_versions": "No version information available.",
-      "original_title": "Original Title",
-      "product_code": "Product Code",
-      "release_date": "Release Date",
-      "remove_dislike": "Remove Dislike",
-      "remove_from_collection": "Remove from Collection",
-      "remove_from_favorites": "Remove from Favorites",
-      "remove_from_wishlist": "Remove from Wishlist",
-      "remove_like": "Remove Like",
-      "scenes": "Scenes",
-      "score": "Score",
-      "series": "Series",
-      "studio": "Studio",
-      "unknown_birth_date": "Unknown",
-      "versions": "Versions"
-    },
-    "tabs": {
-      "community": {
-        "title": "Community"
-      },
-      "manage": {
-        "title": "Manage"
-      },
-      "media": {
-        "fanarts": "Fanarts",
-        "logos": "Logos",
-        "posters": "Posters",
-        "profiles": "Profiles",
-        "title": "Media"
-      },
-      "overview": {
-        "changes": "Changes",
-        "edit": "Edit",
-        "main": "Main",
-        "report": "Report",
-        "title": "Overview"
-      },
-      "share": {
-        "facebook": "Share on Facebook",
-        "link": "Share Link",
-        "title": "Share",
-        "twitter": "Share on Twitter"
-      }
-    }
-  },
-  "movies": {
-    "filter": {
-      "all": "All"
-    },
-    "filterByAge": "Age of featured models",
-    "filterByType": "Type",
-    "sort": {
-      "popularity": "Popularity",
-      "popularityDesc": "Popularity (desc)",
-      "releaseDateDesc": "Release date (desc)",
-      "title": "Title",
-      "titleDesc": "Title (desc)",
-      "updatedAt": "Updated at",
-      "updatedAtDesc": "Updated at (desc)"
-    },
-    "sortBy": "Sort by"
-  },
-  "pages": {
-    "resetPassword": "Reset Password"
-  },
-  "personShow": {
-    "moviesCount": "{number} Movies"
-  },
-  "previews": {
     "movie": {
-      "firstReleasedOn": "Release:",
-      "series": "Series:",
-      "starring": "Starring:",
-      "studio": "Studio:"
+        "reports": {
+            "opened_at": "Opened {date}",
+            "report_type": "Report Type:",
+            "x_reports": "No Reports | {count} Report | {count} Reports"
+        },
+        "show": {
+            "add_to_collection": "Add to Collection",
+            "add_to_favorites": "Add to Favorites",
+            "add_to_wishlist": "Add to Wishlist",
+            "age": "({age} years old)",
+            "barcode": "Barcode",
+            "born": "Born:",
+            "dislike": "Dislike",
+            "files": "Files",
+            "format": "Format",
+            "from": "From {country}",
+            "like": "Like",
+            "measurements": "{height}cm, {bust}-{waist}-{hip}cm",
+            "models": "Models",
+            "noModels": "No model information.",
+            "no_versions": "No version information available.",
+            "original_title": "Original Title",
+            "product_code": "Product Code",
+            "release_date": "Release Date",
+            "remove_dislike": "Remove Dislike",
+            "remove_from_collection": "Remove from Collection",
+            "remove_from_favorites": "Remove from Favorites",
+            "remove_from_wishlist": "Remove from Wishlist",
+            "remove_like": "Remove Like",
+            "scenes": "Scenes",
+            "score": "Score",
+            "series": "Series",
+            "studio": "Studio",
+            "unknown_birth_date": "Unknown",
+            "versions": "Versions"
+        },
+        "tabs": {
+            "community": {
+                "title": "Community"
+            },
+            "manage": {
+                "title": "Manage"
+            },
+            "media": {
+                "fanarts": "Fanarts",
+                "logos": "Logos",
+                "posters": "Posters",
+                "profiles": "Profiles",
+                "title": "Media"
+            },
+            "overview": {
+                "changes": "Changes",
+                "edit": "Edit",
+                "main": "Main",
+                "report": "Report",
+                "title": "Overview"
+            },
+            "share": {
+                "facebook": "Share on Facebook",
+                "link": "Share Link",
+                "title": "Share",
+                "twitter": "Share on Twitter"
+            }
+        }
     },
-    "person": {
-      "recentMovies": "Recent movies:"
-    }
-  },
-  "profile": {
-    "activity": {
-      "created": "Created",
-      "date": "Date",
-      "deleted": "Deleted",
-      "item": "Item",
-      "itemDeleted": "This item has been deleted",
-      "noActivity": "No activity yet.",
-      "thirtyDayActivity": "Activity in the last 30 days",
-      "title": "Activity",
-      "type": "Type",
-      "updated": "Updated"
+    "movies": {
+        "filter": {
+            "all": "All"
+        },
+        "filterByAge": "Age of featured models",
+        "filterByType": "Type",
+        "sort": {
+            "popularity": "Popularity",
+            "popularityDesc": "Popularity (desc)",
+            "releaseDateDesc": "Release date (desc)",
+            "title": "Title",
+            "titleDesc": "Title (desc)",
+            "updatedAt": "Updated at",
+            "updatedAtDesc": "Updated at (desc)"
+        },
+        "sortBy": "Sort by"
     },
-    "averageRating": "Average Rating",
-    "collection": "Collection",
-    "collectionPlaceholder": "You don't have any movies in your collection yet.",
-    "edits": "Total Edits",
-    "editsCount": "No edits | {count} edit | {count} edits",
-    "favorites": "Favorites",
-    "favoritesPlaceholder": "You don't have any movies in your favorites yet.",
-    "memberSince": "Member since {date}",
-    "wishlist": "Wishlist",
-    "wishlistPlaceholder": "You don't have any movies in your wishlist yet."
-  },
-  "register": {
-    "alreadyUser": "Already have an account?",
-    "joinHeader": "Join the largest database of Japanese adult video and gravure movies."
-  },
-  "reports": {
-    "table": {
-      "actions": "Actions",
-      "date": "Date",
-      "status": "Status",
-      "subject": "Subject",
-      "user": "User"
-    }
-  },
-  "search": {
-    "no_results": "No results found",
-    "result_types": {
-      "models": "Models",
-      "movies": "Movies"
-    }
-  },
-  "series": {
-    "moviesPartOf": "Movies"
-  },
-  "settings": {
-    "account": {
-      "content_visibility": "Content Visibility",
-      "content_visibility_tooltip": "Select which content you want to see or hide across the site.",
-      "show_adult_content": "Show adult content",
-      "show_gravure_content": "Show gravure content",
-      "show_gravure_minors_content": "Show gravure content featuring minors",
-      "show_vr_content": "Show VR content",
-      "title": "Account Settings"
+    "pages": {
+        "resetPassword": "Reset Password"
     },
-    "sessions": {
-      "browser": "Browser",
-      "current": "Current",
-      "ip_address": "IP Address",
-      "last_active": "Last Active",
-      "platform": "Platform",
-      "title": "Sessions",
-      "unknown": "Unknown"
+    "personShow": {
+        "moviesCount": "{number} Movies"
     },
-    "tokens": {
-      "actions": "Actions",
-      "copy_token": "Copy Token",
-      "create_token": "Create an API Token",
-      "created": "Created",
-      "last_used": "Last Used",
-      "name": "Name",
-      "neverUsed": "Never",
-      "no_tokens": "You currently have no API tokens. In order to access the API or use tools which require an API token, you will need to create one.",
-      "success": "Your API token has been created. Please copy it now, as it will not be shown again.",
-      "title": "API Tokens"
+    "previews": {
+        "movie": {
+            "firstReleasedOn": "Release:",
+            "series": "Series:",
+            "starring": "Starring:",
+            "studio": "Studio:"
+        },
+        "person": {
+            "recentMovies": "Recent movies:"
+        }
+    },
+    "profile": {
+        "activity": {
+            "created": "Created",
+            "date": "Date",
+            "deleted": "Deleted",
+            "item": "Item",
+            "itemDeleted": "This item has been deleted",
+            "noActivity": "No activity yet.",
+            "thirtyDayActivity": "Activity in the last 30 days",
+            "title": "Activity",
+            "type": "Type",
+            "updated": "Updated"
+        },
+        "averageRating": "Average Rating",
+        "collection": "Collection",
+        "collectionPlaceholder": "You don't have any movies in your collection yet.",
+        "edits": "Total Edits",
+        "editsCount": "No edits | {count} edit | {count} edits",
+        "favorites": "Favorites",
+        "favoritesPlaceholder": "You don't have any movies in your favorites yet.",
+        "memberSince": "Member since {date}",
+        "wishlist": "Wishlist",
+        "wishlistPlaceholder": "You don't have any movies in your wishlist yet."
+    },
+    "register": {
+        "alreadyUser": "Already have an account?",
+        "joinHeader": "Join the largest database of Japanese adult video and gravure movies."
+    },
+    "reports": {
+        "table": {
+            "actions": "Actions",
+            "date": "Date",
+            "status": "Status",
+            "subject": "Subject",
+            "user": "User"
+        }
+    },
+    "search": {
+        "no_results": "No results found",
+        "result_types": {
+            "models": "Models",
+            "movies": "Movies"
+        }
+    },
+    "series": {
+        "moviesPartOf": "Movies"
+    },
+    "settings": {
+        "account": {
+            "content_visibility": "Content Visibility",
+            "content_visibility_tooltip": "Select which content you want to see or hide across the site.",
+            "dangerZone": "Danger Zone",
+            "deleteAccount": "Delete your account",
+            "deleteAccountInfo": "This will render your account permanently inaccessible.\nFor moderation and history reasons, your username may still be visible in parts of the website.",
+            "show_adult_content": "Show adult content",
+            "show_gravure_content": "Show gravure content",
+            "show_gravure_minors_content": "Show gravure content featuring minors",
+            "show_vr_content": "Show VR content",
+            "title": "Account Settings"
+        },
+        "sessions": {
+            "browser": "Browser",
+            "current": "Current",
+            "ip_address": "IP Address",
+            "last_active": "Last Active",
+            "platform": "Platform",
+            "title": "Sessions",
+            "unknown": "Unknown"
+        },
+        "tokens": {
+            "actions": "Actions",
+            "copy_token": "Copy Token",
+            "create_token": "Create an API Token",
+            "created": "Created",
+            "last_used": "Last Used",
+            "name": "Name",
+            "neverUsed": "Never",
+            "no_tokens": "You currently have no API tokens. In order to access the API or use tools which require an API token, you will need to create one.",
+            "success": "Your API token has been created. Please copy it now, as it will not be shown again.",
+            "title": "API Tokens"
+        }
+    },
+    "studio": {
+        "foundedOn": "Founded",
+        "known_for": "Known For",
+        "logo": "Logo",
+        "mostActiveSeries": "Most Active Series",
+        "mostFeaturedModels": "Most Featured Models",
+        "releasedMovies": "Movies"
+    },
+    "user": {
+        "tags": {
+            "admin": "Admin",
+            "banned": "Banned"
+        }
+    },
+    "welcome": {
+        "countCategories": "Categories",
+        "countModels": "Models",
+        "countMovies": "Movies",
+        "countStudios": "Studios",
+        "leaderboard": "Leaderboard",
+        "leaderboardEditsThisWeek": "Edits this week",
+        "leaderboardTotalEdits": "Total Edits",
+        "popularModels": "Popular Models",
+        "popularMovies": "Popular Movies",
+        "recentlyAddedMovies": "Recently Added Movies",
+        "recentlyReleasedMovies": "Recently Released Movies",
+        "recentlyUpdatedMovies": "Recently Updated Movies",
+        "slogan": "Find your next crush"
     }
-  },
-  "studio": {
-    "foundedOn": "Founded",
-    "known_for": "Known For",
-    "logo": "Logo",
-    "mostActiveSeries": "Most Active Series",
-    "mostFeaturedModels": "Most Featured Models",
-    "releasedMovies": "Movies"
-  },
-  "user": {
-    "tags": {
-      "admin": "Admin",
-      "banned": "Banned"
-    }
-  },
-  "welcome": {
-    "countCategories": "Categories",
-    "countModels": "Models",
-    "countMovies": "Movies",
-    "countStudios": "Studios",
-    "leaderboard": "Leaderboard",
-    "leaderboardEditsThisWeek": "Edits this week",
-    "leaderboardTotalEdits": "Total Edits",
-    "popularModels": "Popular Models",
-    "popularMovies": "Popular Movies",
-    "recentlyAddedMovies": "Recently Added Movies",
-    "recentlyReleasedMovies": "Recently Released Movies",
-    "recentlyUpdatedMovies": "Recently Updated Movies",
-    "slogan": "Find your next crush"
-  }
 }


### PR DESCRIPTION
Users can now delete their accounts in the Accounts settings page.

Option is presented in a special red card, to bring more attention to the destructive nature of the action:
![image](https://github.com/kanojo-db/kanojo/assets/19396809/afa3b5b8-079f-4896-a909-ccb6fcc493cf)

Users are not actually deleted from the DB, since we need to keep them for history, moderation and such. They're simply soft deleted, and nobody can login with that account again (They also won't appear in most parts of the website, like the leaderboard and such).